### PR TITLE
Feature/RD-3701 Allow configuration for all docraptor options

### DIFF
--- a/lib/doc_generation_wrapper/adapters/doc_raptor_service/command.rb
+++ b/lib/doc_generation_wrapper/adapters/doc_raptor_service/command.rb
@@ -5,7 +5,9 @@ module DocGenerationWrapper
       class Command
 
         def create! options, &respond_callback
-          response = DocRaptor::DocApi.new.create_async_doc(options)
+          request_parameters = DocGenerationWrapper.configuration.global_parameters.merge(options)
+
+          response = DocRaptor::DocApi.new.create_async_doc(request_parameters)
           respond_callback.call response.status_id if block_given?
           nil
         end

--- a/lib/doc_generation_wrapper/adapters/prince_xml_service/command.rb
+++ b/lib/doc_generation_wrapper/adapters/prince_xml_service/command.rb
@@ -3,21 +3,19 @@ require 'rest-client'
 module DocGenerationWrapper
   module Adapter
     module PrinceXmlService
-
       class Command
-
         def create! options, &respond_callback
           headers = {}
           host    = DocGenerationWrapper.configuration.service_host
           url     = host + '/docs'
 
-          request = RestClient::Request.new(method: :post, url: url, payload: options, headers: headers)
+          request_parameters = DocGenerationWrapper.configuration.global_parameters.merge(options)
+
+          request = RestClient::Request.new(method: :post, url: url, payload: request_parameters, headers: headers)
           response = request.execute
           respond_callback.call response.body
-
           nil
         end
-
       end
     end
   end

--- a/lib/doc_generation_wrapper/configuration.rb
+++ b/lib/doc_generation_wrapper/configuration.rb
@@ -1,10 +1,88 @@
 module DocGenerationWrapper
+  # Simple class to allow configuration of various components of the wrappers.
+  #
+  # All the properties of docraptor and prince xml are allowed to be configured.
+  # These properties have a default value matching those of DocRaptor's documentation.
+  # For details, see https://docraptor.com/documentation/api
   class Configuration
-    attr_accessor :adapter, :service_host
+    attr_accessor :adapter, :service_host, :doc_raptor, :prince_xml
 
     def initialize
       @adapter = :doc_raptor
+      @doc_raptor = DocRaptor.new
+      @prince_xml = PrinceXML.new
       @service_host = 'http://0.0.0.0:5000'
+    end
+
+    # Returns the settings of DocRaptor and PrinceXML as a hash of parameters
+    # to be passed to the HTTP client for making queries.
+    #
+    # It already handles the expected formatting of DocRaptor API (DocRaptor options at the base and
+    # PrinceXML as multipart parameters).
+    def global_parameters
+      {
+        async: doc_raptor.async,
+        document_type: doc_raptor.document_type,
+        javascript: doc_raptor.javascript,
+        pipeline: doc_raptor.pipeline,
+        test: doc_raptor.test,
+        prince_xml: {
+          baseurl: prince_xml.baseurl,
+          media: prince_xml.media,
+          javascript: prince_xml.javascript
+        }
+      }
+    end
+
+    # Configuration pertaining to DocRaptor.
+    #
+    # Allowed Parameters :
+    # - `pipeline`: DocRaptor's pipeline version. Refer to DocRaptor's docs for differences between versions.
+    #               Default : `6`.
+    # - `document_type`: The type of the document.
+    #                    Default : `:pdf`
+    # - `async`: Whether to run the generation asyncronously or syncronously.
+    #            Default : `true`
+    # - `javascript`: Use DocRaptor's JS engine or don't.
+    #                 Note : The version of the JS engine is determined by the pipeline version.
+    #                 Default : `false`
+    # - `test`: Whether to generate the document in test mode or in normal mode.
+    #           Note : in test mode, documents get a watermark and Excel docs are limited to 20 rows.
+    #           Default : `false`
+    class DocRaptor
+      attr_accessor :async, :document_type, :javascript, :pipeline, :test
+
+      def initialize
+        @async         = false
+        @document_type = :pdf
+        @javascript    = false
+        @pipeline      = 6
+        @test          = false
+      end
+    end
+
+    # Configuration pertaining to PrinceXML.
+    # Disregarded most of the options, as they're not that useful in 90% of cases.
+    #
+    # Allowed parameters :
+    # - `baseurl`: The base url for fetching assets (only relevant for relative paths)
+    #              Default : `nil`
+    # - `media`: The type of media the document is expected to be viewed on.
+    #            Default : `:print`
+    # - `javascript`: Whether to use PrinceXML's JS engine.
+    #                 Default : `false`
+    # - `http_timeout`: How long to wait when requesting external resources.
+    #                   Value can be from 1 to 60 in seconds.
+    #                   Default : `10`
+    class PrinceXML
+      attr_accessor :baseurl, :http_timeout, :javascript, :media
+
+      def initialize
+        @baseurl = nil
+        @http_timeout = 10
+        @javascript = false
+        @media   = :print
+      end
     end
   end
 end

--- a/lib/doc_generation_wrapper/version.rb
+++ b/lib/doc_generation_wrapper/version.rb
@@ -1,3 +1,3 @@
 module DocGenerationWrapper
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/doc_generation_wrapper/configuration_spec.rb
+++ b/spec/doc_generation_wrapper/configuration_spec.rb
@@ -2,20 +2,125 @@ require 'spec_helper'
 
 module DocGenerationWrapper
   describe Configuration do
-    let(:configuration) { Configuration.new }
-
     describe 'default config' do
-      let(:adapter)      { :doc_raptor }
-      let(:service_host) { 'http://0.0.0.0:5000' }
+      let(:configuration) { Configuration.new }
+      let(:doc_raptor) { configuration.doc_raptor }
+      let(:prince_xml) { configuration.prince_xml }
 
-      it 'adapter is doc_raptor' do
+      let(:adapter)               { :doc_raptor }
+      let(:async)                 { false }
+      let(:baseurl)               { nil }
+      let(:doc_raptor_javascript) { false }
+      let(:document_type)         { :pdf }
+      let(:media)                 { :print }
+      let(:pipeline)              { 6 }
+      let(:prince_xml_javascript) { false }
+      let(:service_host)          { 'http://0.0.0.0:5000' }
+      let(:test)                  { false }
+
+      its 'adapter is doc_raptor' do
         expect(configuration.adapter).to eq(adapter)
       end
 
-      it 'service host is local sinatra hosting' do
+      its 'service host is local sinatra hosting' do
         expect(configuration.service_host).to eq(service_host)
+      end
+
+      describe 'doc raptor config' do
+        its 'async is false' do
+          expect(doc_raptor.async).to eq(async)
+        end
+
+        its 'javascript options is false' do
+          expect(doc_raptor.javascript).to eq(doc_raptor_javascript)
+        end
+
+        its 'document_type is :pdf' do
+          expect(doc_raptor.document_type).to eq(document_type)
+        end
+
+        its 'pipeline is 6' do
+          expect(doc_raptor.pipeline).to eq(pipeline)
+        end
+
+        its 'test is false' do
+          expect(doc_raptor.test).to eq(test)
+        end
+      end
+
+      describe 'prince xml config' do
+        its 'baseurl is nil' do
+          expect(prince_xml.baseurl).to eq(baseurl)
+        end
+
+        its 'media is :screen' do
+          expect(prince_xml.media).to eq(media)
+        end
+
+        its 'javascript option is false' do
+          expect(prince_xml.javascript).to eq(prince_xml_javascript)
+        end
       end
     end
 
+    describe 'non default config' do
+      let(:configuration) { Configuration.new }
+
+      let(:async)                 { true }
+      let(:baseurl)               { 'b.com' }
+      let(:doc_raptor_javascript) { true }
+      let(:document_type)         { :xls }
+      let(:media)                 { :screen }
+      let(:pipeline)              { 4 }
+      let(:prince_xml_javascript) { true }
+      let(:test)                  { true }
+
+      before do
+        configuration.doc_raptor.async = true
+        configuration.doc_raptor.document_type = :xls
+        configuration.doc_raptor.javascript = true
+        configuration.doc_raptor.pipeline = 4
+        configuration.doc_raptor.test = true
+        configuration.prince_xml.baseurl = 'b.com'
+        configuration.prince_xml.javascript = true
+        configuration.prince_xml.media = :screen
+      end
+
+      describe 'doc raptor config' do
+        its 'async is true' do
+          expect(configuration.doc_raptor.async).to eq(async)
+        end
+
+        its 'javascript options is true' do
+          expect(configuration.doc_raptor.javascript).to eq(doc_raptor_javascript)
+        end
+
+        its 'document_type is :xls' do
+          expect(configuration.doc_raptor.document_type).to eq(document_type)
+        end
+
+        its 'pipeline is 4' do
+          expect(configuration.doc_raptor.pipeline).to eq(pipeline)
+        end
+
+        its 'test is false' do
+          expect(configuration.doc_raptor.test).to eq(test)
+        end
+      end
+
+      describe 'prince xml config' do
+        its 'baseurl is b.com' do
+          expect(configuration.prince_xml.baseurl).to eq(baseurl)
+        end
+
+        its 'media is :print' do
+          expect(configuration.prince_xml.media).to eq(media)
+        end
+
+        its 'javascript option is true' do
+          expect(configuration.prince_xml.javascript).to eq(prince_xml_javascript)
+        end
+      end
+    end
   end
 end

--- a/spec/doc_generation_wrapper_spec.rb
+++ b/spec/doc_generation_wrapper_spec.rb
@@ -14,7 +14,18 @@ module DocGenerationWrapper
     end
 
     describe '#create!' do
-      let(:options) {{}}
+      let(:options) {{
+        async: true,
+        document_type: :odf,
+        javascript: false,
+        pipeline: 6,
+        test: true,
+        prince_xml: {
+          baseurl: nil,
+          media: :print,
+          javascript: false
+        }
+      }}
 
       before do
         doc_raptor_double = double


### PR DESCRIPTION
- Allow more options to DocRaptor requests
- Add tests

Comes with global configuration options with defaults, which can be replaced in an initializer. Alternatively, I made sure the options could still be passed for each request if needed.